### PR TITLE
use u8 for string examples instead of i8

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Fix string examples to use `*cost u8` instead of
+    `*const i8`
 
 0.15      2023-02-21 08:05:34 -0700
   - Bump Alien::Rust prereq to 0.03 for better handling

--- a/examples/Person/ffi/src/lib.rs
+++ b/examples/Person/ffi/src/lib.rs
@@ -33,8 +33,8 @@ type CPerson = c_void;
 
 #[no_mangle]
 pub extern "C" fn person_new(
-    _class: *const i8,
-    name: *const i8,
+    _class: *const u8,
+    name: *const u8,
     lucky_number: i32,
 ) -> *mut CPerson {
     let name = unsafe { CStr::from_ptr(name) };
@@ -43,7 +43,7 @@ pub extern "C" fn person_new(
 }
 
 #[no_mangle]
-pub extern "C" fn person_name(p: *mut CPerson) -> *const i8 {
+pub extern "C" fn person_name(p: *mut CPerson) -> *const u8 {
     thread_local!(
         static KEEP: RefCell<Option<CString>> = RefCell::new(None);
     );
@@ -58,7 +58,7 @@ pub extern "C" fn person_name(p: *mut CPerson) -> *const i8 {
 }
 
 #[no_mangle]
-pub extern "C" fn person_rename(p: *mut CPerson, new: *const i8) {
+pub extern "C" fn person_rename(p: *mut CPerson, new: *const u8) {
     let new = unsafe { CStr::from_ptr(new) };
     let p = unsafe { &mut *(p as *mut Person) };
     if let Ok(new) = new.to_str() {

--- a/examples/Person/ffi/src/test.rs
+++ b/examples/Person/ffi/src/test.rs
@@ -18,7 +18,7 @@ const TEST_OTHER_NAME: *const u8 = b"Graham THE Ollis\0" as *const u8;
 
 #[test]
 fn c_lib_works() {
-    let plicease = crate::person_new(TEST_CLASS as *const i8, TEST_NAME as *const i8, 42);
+    let plicease = crate::person_new(TEST_CLASS as *const u8, TEST_NAME as *const u8, 42);
     assert_eq!(
         unsafe {
             CStr::from_ptr(crate::person_name(plicease))
@@ -29,7 +29,7 @@ fn c_lib_works() {
     );
     assert_eq!(crate::person_lucky_number(plicease), 42);
 
-    crate::person_rename(plicease, TEST_OTHER_NAME as *const i8);
+    crate::person_rename(plicease, TEST_OTHER_NAME as *const u8);
 
     assert_eq!(
         unsafe {

--- a/examples/callback.rs
+++ b/examples/callback.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::CString;
 
-type PerlLog = extern "C" fn(line: *const i8);
+type PerlLog = extern "C" fn(line: *const u8);
 
 #[no_mangle]
 pub extern "C" fn rust_log(logf: PerlLog) {

--- a/examples/string/argument.rs
+++ b/examples/string/argument.rs
@@ -3,7 +3,7 @@
 use std::ffi::CStr;
 
 #[no_mangle]
-pub extern "C" fn how_many_characters(s: *const i8) -> isize {
+pub extern "C" fn how_many_characters(s: *const u8) -> isize {
     if s.is_null() {
         return -1;
     }

--- a/examples/string/return/keep.rs
+++ b/examples/string/return/keep.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 use std::iter;
 
 #[no_mangle]
-pub extern "C" fn theme_song_generate(length: u8) -> *const i8 {
+pub extern "C" fn theme_song_generate(length: u8) -> *const u8 {
     thread_local! {
         static KEEP: RefCell<Option<CString>> = RefCell::new(None);
     }

--- a/examples/string/return/return.rs
+++ b/examples/string/return/return.rs
@@ -4,7 +4,7 @@ use std::ffi::CString;
 use std::iter;
 
 #[no_mangle]
-pub extern "C" fn theme_song_generate(length: u8) -> *mut i8 {
+pub extern "C" fn theme_song_generate(length: u8) -> *mut u8 {
     let mut song = String::from("💣 ");
     song.extend(iter::repeat("na ").take(length as usize));
     song.push_str("Batman! 💣");
@@ -14,7 +14,7 @@ pub extern "C" fn theme_song_generate(length: u8) -> *mut i8 {
 }
 
 #[no_mangle]
-pub extern "C" fn theme_song_free(s: *mut i8) {
+pub extern "C" fn theme_song_free(s: *mut u8) {
     if s.is_null() {
         return;
     }


### PR DESCRIPTION
This is not the right fix.  On Intel these functions expect i8 but on linux arm they expect u8 (macos arm is still i8).  Found some hints here:
https://github.com/fede1024/rust-rdkafka/issues/121